### PR TITLE
Feature/cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,14 @@ else()
   message(STATUS "Building static version...")
 endif()
 
+# generate a framework for the above lib
+set_target_properties( sqlcppbridge PROPERTIES
+  FRAMEWORK TRUE
+  FRAMEWORK_VERSION C
+  VERSION ${project_version}
+  SOVERSION 1.0.0
+  PUBLIC_HEADER "${HEADERS}" )
+
 # installation
 install (TARGETS sqlcppbridge DESTINATION lib)
 install (FILES ${HEADERS} DESTINATION include)


### PR DESCRIPTION
This implements a very basic framework wrapper (apparently cmake already was able to do that on iOS and MacOSX). 
Please note that it also generates a default Info.plist which can be completely customized if desired. See https://cmake.org/cmake/help/latest/prop_tgt/FRAMEWORK.html for more details on that. I have not found a way to omit Info.plist generation however (as current build_framework script does).