### PR TITLE
Feature/cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,59 +1,57 @@
-cmake_minimum_required (VERSION 3.15...3.16.2)
+cmake_minimum_required ( VERSION 3.15...3.16.2 )
 
 set( CMAKE_PROJECT_INCLUDE_BEFORE 
   "${CMAKE_CURRENT_LIST_DIR}/common-project-include.in" )
 
-project( SQLCppBridge 
-         VERSION "${project_version}"
-         DESCRIPTION "${project_description}"
-         HOMEPAGE_URL "${project_homepage}"
-         LANGUAGES C CXX )
+project ( SQLCppBridge 
+          VERSION "${project_version}"
+          DESCRIPTION "${project_description}"
+          HOMEPAGE_URL "${project_homepage}"
+          LANGUAGES C CXX )
 
-# set some project-wide flags
-set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-overflow -Wno-varargs -O3" )
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-overflow -Wno-varargs -O3" )
+# possible options
+option ( BUILD_SHARED    "Build shared library instead of static" OFF )
+option ( BUILD_FRAMEWORK "Build framework" OFF )
+option ( REQUIRE_SQLITE  "Link against sqlite3" ON )
 
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-stdlib=libc++" COMPILER_SUPPORTS_LIBCPP)
-CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
+file ( GLOB_RECURSE ALL_SRC "SQLBridge/src/*.cpp" )
+file ( GLOB_RECURSE HEADERS "SQLBridge/include/*.hpp" )
 
-if(COMPILER_SUPPORTS_CXX14)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-  if(COMPILER_SUPPORTS_LIBCPP)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-  endif()
-else()
-  message( STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++14 support. Please use a different C++ compiler." )
-endif()
-
-message( STATUS "CMAKE_CXX_FLAGS: " ${CMAKE_CXX_FLAGS} )
-
-# set includes
-include_directories("SQLBridge/src" "SQLBridge/include")
-
-# all source files
-file(GLOB_RECURSE SOURCES SQLBridge/src/*.cpp)
-
-# headers
-file(GLOB_RECURSE HEADERS SQLBridge/include/*.h)
-
-# lib
-if(BUILD_SHARED)
-  add_library (sqlcppbridge SHARED ${SOURCES} ${HEADERS})
+if ( BUILD_SHARED )
+  add_library ( ${PROJECT_NAME} SHARED "${ALL_SRC}" "${HEADERS}" )
   message(STATUS "Building shared version...")
 else()
-  add_library (sqlcppbridge STATIC ${SOURCES} ${HEADERS})
+  add_library ( ${PROJECT_NAME} STATIC "${ALL_SRC}" "${HEADERS}" )
   message(STATUS "Building static version...")
 endif()
 
+add_library ( lib::SQLCppBridge ALIAS ${PROJECT_NAME} )
+
+target_compile_features ( ${PROJECT_NAME}
+    PRIVATE  cxx_std_14 )
+
+target_include_directories ( ${PROJECT_NAME}
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/SQLBridge/src" "${CMAKE_CURRENT_SOURCE_DIR}/SQLBridge/include"
+)
+
+if ( REQUIRE_SQLITE ) 
+  find_package ( SQLite3 )
+
+  target_link_libraries (
+    ${PROJECT_NAME}
+      INTERFACE SQLite::SQLite3 )
+endif()
+
 # generate a framework for the above lib
-set_target_properties( sqlcppbridge PROPERTIES
-  FRAMEWORK TRUE
-  FRAMEWORK_VERSION C
-  VERSION ${project_version}
-  SOVERSION 1.0.0
-  PUBLIC_HEADER "${HEADERS}" )
+if ( BUILD_FRAMEWORK )
+  set_target_properties( ${PROJECT_NAME} PROPERTIES
+    FRAMEWORK TRUE
+    FRAMEWORK_VERSION C
+    VERSION           ${project_version}
+    SOVERSION         1.0.0
+    PUBLIC_HEADER     "${HEADERS}" )
+endif()
 
 # installation
-install (TARGETS sqlcppbridge DESTINATION lib)
-install (FILES ${HEADERS} DESTINATION include)
+install ( TARGETS ${PROJECT_NAME} DESTINATION lib )
+install ( FILES ${HEADERS} DESTINATION include )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,26 +4,43 @@ set( CMAKE_PROJECT_INCLUDE_BEFORE
   "${CMAKE_CURRENT_LIST_DIR}/common-project-include.in" )
 
 project ( SQLCppBridge 
-          VERSION "${project_version}"
-          DESCRIPTION "${project_description}"
-          HOMEPAGE_URL "${project_homepage}"
-          LANGUAGES C CXX )
+  VERSION      "${project_version}"
+  DESCRIPTION  "${project_description}"
+  HOMEPAGE_URL "${project_homepage}"
+  LANGUAGES    C CXX )
 
 # possible options
 option ( BUILD_SHARED    "Build shared library instead of static" OFF )
 option ( BUILD_FRAMEWORK "Build framework" OFF )
 option ( REQUIRE_SQLITE  "Link against sqlite3" ON )
 
+# if the user specified a platform to build for (i.e. OS)
+# we assume the user wants a framework
+get_property( PLATFORM_SPECIFIED 
+  VARIABLE PROPERTY PLATFORM  
+  SET )
+
+if ( PLATFORM_SPECIFIED )  
+  set ( BUILD_FRAMEWORK ON )
+endif()
+
 file ( GLOB_RECURSE ALL_SRC "SQLBridge/src/*.cpp" )
-file ( GLOB_RECURSE HEADERS "SQLBridge/include/*.hpp" )
+file ( GLOB_RECURSE HEADERS "SQLBridge/include/*.h" )
 
 if ( BUILD_SHARED )
-  add_library ( ${PROJECT_NAME} SHARED "${ALL_SRC}" "${HEADERS}" )
-  message(STATUS "Building shared version...")
+  add_library ( ${PROJECT_NAME} SHARED "${ALL_SRC}" "${HEADERS}" )  
+  set ( REQUIRE_SQLITE ON ) # sqlite linkage is required for shared library
 else()
-  add_library ( ${PROJECT_NAME} STATIC "${ALL_SRC}" "${HEADERS}" )
-  message(STATUS "Building static version...")
+  add_library ( ${PROJECT_NAME} STATIC "${ALL_SRC}" "${HEADERS}" )  
 endif()
+
+
+MESSAGE ( STATUS "${PROJECT_NAME} Options:" )
+MESSAGE ( STATUS "----" )
+MESSAGE ( STATUS "Build shared library:   " ${BUILD_SHARED} )
+MESSAGE ( STATUS "Build framework:        " ${BUILD_FRAMEWORK} )
+MESSAGE ( STATUS "Build require sqlite:   " ${REQUIRE_SQLITE} )
+MESSAGE ( STATUS "----" )
 
 add_library ( lib::SQLCppBridge ALIAS ${PROJECT_NAME} )
 
@@ -31,25 +48,29 @@ target_compile_features ( ${PROJECT_NAME}
     PRIVATE  cxx_std_14 )
 
 target_include_directories ( ${PROJECT_NAME}
-    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/SQLBridge/src" "${CMAKE_CURRENT_SOURCE_DIR}/SQLBridge/include"
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/SQLBridge/src" 
+    PUBLIC  "${CMAKE_CURRENT_SOURCE_DIR}/SQLBridge/include"
 )
+
+set_target_properties( ${PROJECT_NAME} PROPERTIES
+  FRAMEWORK ${BUILD_FRAMEWORK}
+  FRAMEWORK_VERSION C
+  VERSION           ${project_version}
+  SOVERSION         1.0.0
+  PUBLIC_HEADER     "${HEADERS}" )
 
 if ( REQUIRE_SQLITE ) 
   find_package ( SQLite3 )
 
-  target_link_libraries (
-    ${PROJECT_NAME}
-      INTERFACE SQLite::SQLite3 )
-endif()
-
-# generate a framework for the above lib
-if ( BUILD_FRAMEWORK )
-  set_target_properties( ${PROJECT_NAME} PROPERTIES
-    FRAMEWORK TRUE
-    FRAMEWORK_VERSION C
-    VERSION           ${project_version}
-    SOVERSION         1.0.0
-    PUBLIC_HEADER     "${HEADERS}" )
+  if ( BUILD_SHARED )
+    target_link_libraries (
+      ${PROJECT_NAME}
+        PRIVATE SQLite::SQLite3 ) # link right into the shared library
+  else()
+    target_link_libraries (
+      ${PROJECT_NAME}
+        INTERFACE SQLite::SQLite3 ) # just set as requirement for clients
+  endif()
 endif()
 
 # installation

--- a/README.md
+++ b/README.md
@@ -52,21 +52,50 @@ are not supported either.
 Build:
 -------------
 You can use the script:
-./make_framework
+
+    ./make_framework
+
 to create ./build/iOS/sqlcppbridge.framework and ./build/MacOS/sqlcppbridge.framework
 which includes armv7, armv7s, armv7k, arm64, arm64e, i386  and x86_64 architectures
-to use in the whole set of iOS-devices and
-iOS-simulators
+to use in the whole set of iOS-devices and iOS-simulators.
 
-...or you can simple run 'make' utility to create the static library for the default
-environment
+Alternatively you can simply run 'make' utility to create the static library for the default environment.
 
-You can also build it using CMake:
+You can also build it using CMake (for iOS):
 
     mkdir build.cmake && cd build.cmake
     cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/ios.toolchain.cmake -DPLATFORM=OS
 
 For more details on available PLATFORM options see https://github.com/leetal/ios-cmake#options
+
+Build it as a `static` library for the current platform:
+
+    mkdir build.cmake && cd build.cmake
+    cmake ..
+
+Or a `shared` library for the current platform:
+
+    mkdir build.cmake && cd build.cmake
+    cmake -DBUILD_SHARED=ON ..
+
+By default sqlite3 library is detected and built into the shared library OR specified as a requirement for the static library flavour (see below).
+If you want to avoid including sqlite3 (e.g. you already have sqlite3 in your project) you can do so using the `-DREQUIRE_SQLITE=OFF` option:
+
+    mkdir build.cmake && cd build.cmake
+    cmake -DREQUIRE_SQLITE=OFF ..
+
+**Note** that this is only possible for a static library; The shared library will force linkage against sqlite3 and contain it.
+
+CMake can also be used for easy integration with SQLCppBridge (assuming SQLCppBridge is used as a git submodule or dropped to `lib/SQLCppBridge`):
+
+    add_subdirectory ( "${CMAKE_SOURCE_DIR}/lib/SQLCppBridge" EXCLUDE_FROM_ALL )
+    ...
+    target_link_libraries (
+      myTarget
+        PRIVATE  lib::SQLCppBridge
+        ... )
+
+The above example will automatically link myTarget against SQLCppBridge as well as setup required include directories.
 
 Install:
 -------------


### PR DESCRIPTION
This implements a few things:
* **REQUIRE_SQLITE** option that allows the user of this library to implicitly tell cmake to avoid linking against sqlite. But since sqlite3 is vital for the final binary to work, this option is ON by default.
*  **BUILD_FRAMEWORK** option that allows to enable/disable framework generation for osx/ios (depending on toolchain and PLATFORM options)
* **BUILD_SHARED** option that builds a shared library instead of a static library. This option also forces linkage against sqlite3 overriding the REQUIRE_SQLITE option.

Please take a look at the updated README.md file for more details.